### PR TITLE
fix: support variables with double dash

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,10 @@ const fn = (vars = {}) => {
   return (css) => {
     const rule = postcss.rule({ selector: ':root' })
     const props = Object.keys(vars)
-    const decls = props.map((prop) => postcss.decl({ prop: `--${prop}`, value: vars[prop] }))
+    const decls = props.map((prop) => {
+      const propName = prop.indexOf('--') === 0 ? prop : `--${prop}`
+      return postcss.decl({ prop: propName, value: vars[prop] })
+    })
     css.prepend(rule.append(decls))
   }
 }

--- a/test.js
+++ b/test.js
@@ -15,4 +15,16 @@ describe(name, () => {
       ':root {\n    --colorAlpha: #000;\n    --colorBeta: #111\n}\n/* code */'
     )
   })
+
+  it('works with with variables defined with a double dash', () => {
+    const variables = {
+      '--colorAlpha': '#000',
+      '--colorBeta': '#111'
+    }
+
+    assume(postcss([lib(variables)]).process('/* code */').css)
+    .equals(
+      ':root {\n    --colorAlpha: #000;\n    --colorBeta: #111\n}\n/* code */'
+    )
+  })
 })


### PR DESCRIPTION
[postcss-custom-properties](https://github.com/postcss/postcss-custom-properties) accepts also variables starting with double dash `--`, so I added support for them 🎄 

Nice plugin anyway!